### PR TITLE
fix: resolve kotlin compilation errors with expo sdk 54

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   }
 
   dependencies {
-    classpath "com.android.tools.build:gradle:7.2.1"
+    classpath "com.android.tools.build:gradle:8.1.4"
     // noinspection DifferentKotlinGradleVersion
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
@@ -77,8 +77,13 @@ android {
   }
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_1_8
-    targetCompatibility JavaVersion.VERSION_1_8
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = "17"
+    allWarningsAsErrors = false
   }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
-InAppUpdates_kotlinVersion=1.7.0
-InAppUpdates_minSdkVersion=21
-InAppUpdates_targetSdkVersion=31
-InAppUpdates_compileSdkVersion=31
-InAppUpdates_ndkversion=21.4.7075529
+InAppUpdates_kotlinVersion=1.9.23
+InAppUpdates_minSdkVersion=24
+InAppUpdates_targetSdkVersion=34
+InAppUpdates_compileSdkVersion=34
+InAppUpdates_ndkversion=26.1.10909125


### PR DESCRIPTION
- Update Kotlin from 1.7.0 to 1.9.23
- Update Android Gradle Plugin from 7.2.1 to 8.1.4
- Update compileSdkVersion and targetSdkVersion to 34
- Update minSdkVersion to 24 (Expo SDK 54 requirement)
- Update NDK to 26.1.10909125
- Update JVM target to Java 17 for buildTools compatibility
- Add kotlinOptions configuration

Resolves GradleCompilerRunnerWithWorkers and JVM-target compatibility failures with Expo SDK 54.