### PR TITLE
fix: resolve currentActivity reference for React Native 0.86+

### DIFF
--- a/android/src/main/java/com/inappupdates/InAppUpdatesModule.kt
+++ b/android/src/main/java/com/inappupdates/InAppUpdatesModule.kt
@@ -45,7 +45,7 @@ class InAppUpdatesModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun checkForUpdate(updateType: String, isMock: Boolean, promise: Promise) {
-        val activity = currentActivity ?: return promise.reject("NO_ACTIVITY", "No current activity")
+        val activity = reactApplicationContext.currentActivity ?: return promise.reject("NO_ACTIVITY", "No current activity")
         val manager = getAppUpdateManager(isMock)
 
         manager.appUpdateInfo.addOnSuccessListener { appUpdateInfo ->


### PR DESCRIPTION
### Description
This PR resolves the `Unresolved reference 'currentActivity'` Android build failure that occurs when compiling this library against React Native 0.86+.

Due to architecture changes in recent React Native versions, direct access to `currentActivity` fails during the `:react-native-in-app-updates:compileDebugKotlin` task. Routing the call through `reactApplicationContext.currentActivity` restores compatibility with the new engine while maintaining expected behavior.

Fixes #10 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have built and run the development build successfully (EAS Build / Android).
- [x] I have ran `yarn lint` and `yarn typecheck`.
- [x] My commit message follows the Conventional Commits specification.